### PR TITLE
Refactor: centralize site-list logic into shared module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ web-ext-artifacts/
 
 # Node modules (if added in the future)
 node_modules/
+package-lock.json
 
 # Python virtual environment (used for icon generation)
 venv/

--- a/shared/site-lists.js
+++ b/shared/site-lists.js
@@ -1,9 +1,11 @@
+// Shared site-list logic for Our Morning Coffee extension
+// UMD pattern: CommonJS export for Node tests, global variable for browser
+
 (function initSiteLists(root, factory) {
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = factory();
     return;
   }
-
   root.OurMorningCoffeeSiteLists = factory();
 }(typeof globalThis !== 'undefined' ? globalThis : this, function createSiteListsModule() {
   const dayKeys = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];

--- a/test/site-lists.test.js
+++ b/test/site-lists.test.js
@@ -20,6 +20,12 @@ test('normalizeSiteLists keeps known lists and drops invalid values', () => {
   assert.equal(normalized.unknown, undefined);
 });
 
+test('normalizeSiteLists handles null input', () => {
+  const normalized = normalizeSiteLists(null);
+  assert.deepEqual(Object.keys(normalized), validListKeys);
+  assert.deepEqual(normalized.everyday, []);
+});
+
 test('getCategoryKeyForDay maps weekends and weekdays correctly', () => {
   assert.equal(getCategoryKeyForDay(0), 'weekends');
   assert.equal(getCategoryKeyForDay(6), 'weekends');


### PR DESCRIPTION
Extract duplicated normalizeSiteLists, getCategoryKeyForDay, and day constants from background.js, popup.js, and options.js into a single shared/site-lists.js module using UMD pattern for browser/Node compatibility.
   - Add unit tests using Node's built-in test runner
   - Add package.json with test script
   - Add package-lock.json to .gitignore

 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>